### PR TITLE
Expanding alphabet to Markov chains

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,13 @@ The format is based on Keep a Changelog and this project adheres to Semantic Ver
 
 ## [UNRELEASED](https://github.com/camilogarciabotero/GeneFinder.jl/compare/v0.0.10...main)
 
-## [0.1.0]
+## [0.2.0]
+
+- Exapanding the alphabets to RNA and AA to its Markov chains.
+- Improving runtime and allocations
+- Refacotring and renaming of internal functions
+
+## [0.1.X]
 
 - This version has some clean ups and a new faster version of `dinucleotides` counts thanks to @gdalle. See [here the discussion](https://discourse.julialang.org/t/optimizing-dinucleotides-count-in-a-dna-sequence-type-longdna/101583/4?u=camilogarciabotero)
 ## [0.1.0]

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "BioMarkovChains"
 uuid = "f861b655-cb5f-42ce-b66a-341b542d4f2c"
 authors = ["Camilo García<ca.garcia2@uniandes.edu.co>"]
-version = "0.1.5"
+version = "0.2.0"
 
 [deps]
 BioSequences = "7e6ae17a-c86d-528c-b3b9-7f778a29fe59"
@@ -19,3 +19,10 @@ StatsBase = "0.34.0"
 TestItemRunner = "0.2"
 TestItems = "0.1"
 julia = "1.9"
+
+[extras]
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+TestItemRunner = "f8b46487-2199-4994-9208-9a1283c18c0a"
+
+[targets]
+test = ["Test"]

--- a/src/BioMarkovChains.jl
+++ b/src/BioMarkovChains.jl
@@ -1,19 +1,32 @@
 module BioMarkovChains
 
 using BioSequences:
-    ACGT,
-    DNA,
-    DNA_A,
-    DNA_C,
-    DNA_G,
-    DNA_T,
-    DNAAlphabet,
-    NucleicAcidAlphabet,
     LongSequence,
     LongSubSeq,
+    LongNuc,
     LongDNA,
+    LongRNA,
+    ACGT,
+    ACGU,
+    NucleicAcidAlphabet,
+    DNA,
+    DNAAlphabet,
+    DNA_Gap, DNA_A, DNA_C, DNA_M, DNA_G, DNA_R, DNA_S, DNA_V, DNA_T, DNA_W, DNA_Y, DNA_H, DNA_K, DNA_D, DNA_B, DNA_N,
+    
+    #RNA
+    RNA,
+    RNA_Gap, RNA_A, RNA_C, RNA_M, RNA_G, RNA_R, RNA_S, RNA_V, RNA_U, RNA_W, RNA_Y, RNA_H, RNA_K, RNA_D, RNA_B, RNA_N,
+    
+    #AminoAcids
+    AminoAcid,
+    AminoAcidAlphabet,
+    LongAA,
+    AA_A, AA_R, AA_N, AA_D, AA_C, AA_Q, AA_E, AA_G, AA_H, AA_I, AA_L, AA_K, AA_M, AA_F, AA_P, AA_S, AA_T, AA_W, AA_Y, AA_V, AA_O, AA_U, AA_B, AA_J, AA_Z, AA_X, AA_Term, AA_Gap,
+
+    # Other functions
     alphabet,
     @biore_str
+    
 
 using MarkovChainHammer.Trajectory: generate
 using PrecompileTools: @setup_workload, @compile_workload
@@ -21,13 +34,13 @@ using TestItems: @testitem
 using StatsBase: countmap
 
 include("types.jl")
-export TransitionCountMatrix, TransitionProbabilityMatrix, TransitionModel
+export TransitionModel
 
 include("utils.jl")
-export dinucleotides, hasprematurestop
+export transitions, hasprematurestop
 
 include("transitions.jl")
-export transition_count_matrix, transition_probability_matrix, transition_model, initial_distribution, sequenceprobability
+export initials, transition_count_matrix, transition_probability_matrix, transition_model, dnaseqprobability
 
 include("models.jl")
 export ECOLICDS, ECOLINOCDS
@@ -45,10 +58,10 @@ include("extended.jl")
     @compile_workload begin
         # all calls in this block will be precompiled, regardless of whether
         # they belong to your package or not (on Julia 1.8 and higher)
-        dinucleotides(seq)
+        transitions(seq)
         transition_count_matrix(seq)
         transition_probability_matrix(seq)
-        sequenceprobability(seq, ECOLICDS)
+        dnaseqprobability(seq, ECOLICDS)
         transition_model(seq)
         perronfrobenius(seq)
     end

--- a/src/extended.jl
+++ b/src/extended.jl
@@ -1,43 +1,5 @@
 import Base: show
 
-function Base.show(io::IO, tcm::TransitionCountMatrix)
-    nucleotides = sort(collect(keys(tcm.order)))
-
-    # Print type
-    println(io, "TCM{$(typeof(tcm.order)), $(typeof(tcm.counts)):")
-
-    # Print header
-    max_digits = maximum([length(string(maximum(tcm.counts[:, i]))) for i in 1:size(tcm.counts, 2)])
-    header_str = "   " * join([rpad(n, max_digits+1) for n in nucleotides], "")
-    println(io, header_str)
-
-    # Print rows
-    for (i, nucleotide1) in enumerate(nucleotides)
-        row = tcm.counts[i, :]
-        row_str = join([rpad(string(x), max_digits+1) for x in row], "")
-        println(io, "$nucleotide1  $row_str")
-    end
-end
-
-function Base.show(io::IO, tpm::TransitionProbabilityMatrix)
-    nucleotides = sort(collect(keys(tpm.order)))
-
-    # Print type
-    println(io, "TPM{$(typeof(tpm.order)), $(typeof(tpm.probabilities)):")
-
-    # Print header
-    max_digits = maximum([length(string(maximum(round.(tpm.probabilities[:, i], digits = 3)))) for i in 1:size(tpm.probabilities, 2)])
-    header_str = "   " * join([rpad(n, max_digits+1) for n in nucleotides], "")
-    println(io, header_str)
-
-    # Print rows
-    for (i, nucleotide1) in enumerate(nucleotides)
-        row = round.(tpm.probabilities[i, :], digits = 3)
-        row_str = join([rpad(string(x), max_digits+1) for x in row], "")
-        println(io, "$nucleotide1  $row_str")
-    end
-end
-
 function Base.show(io::IO, model::TransitionModel)
     # Print the type name
     println(io, "TransitionModel:")

--- a/src/models.jl
+++ b/src/models.jl
@@ -6,9 +6,9 @@ const ECOLICDS = begin
         0.178 0.217 0.338 0.267
     ]
 
-    initials = [0.245, 0.243, 0.273, 0.239]
+    inits = [0.245, 0.243, 0.273, 0.239]
 
-    transition_model(tpm, initials)
+    transition_model(tpm, inits)
 end
 
 const ECOLINOCDS = begin
@@ -19,7 +19,7 @@ const ECOLINOCDS = begin
         0.207 0.219 0.259 0.314
     ]
     
-    initials = [0.262, 0.239, 0.240, 0.259]
+    inits = [0.262, 0.239, 0.240, 0.259]
     
-    transition_model(tpm, initials)
+    transition_model(tpm, inits)
 end

--- a/src/perronfrobenius.jl
+++ b/src/perronfrobenius.jl
@@ -1,7 +1,7 @@
 ### MarkdovChainHammer.jl ###
 
 function perronfrobenius(sequence::LongNucOrView{4}, n::Int64=1)
-    tpm = transition_probability_matrix(sequence, n).probabilities
+    tpm = transition_probability_matrix(sequence, n)
     pf = transpose(tpm)
     return copy(pf)
 end

--- a/src/types.jl
+++ b/src/types.jl
@@ -1,4 +1,3 @@
-
 abstract type BioMarkovChain end
 
 const LongNucOrView{N} = Union{LongSequence{<:NucleicAcidAlphabet{N}},LongSubSeq{<:NucleicAcidAlphabet{N}}}
@@ -24,77 +23,7 @@ const DINUCLEICINDEXES = Dict(
     LongDNA{4}("TT") => [4, 4],
 )
 
-# const DINUCLEOTIDES = vec([LongSequence{DNAAlphabet{2}}([i, j]) for i in ACGT, j in ACGT])
-
-# const DINUCLEOTIDES = let
-#     x = [LongSequence{DNAAlphabet{2}}([i, j]) for i in ACGT, j in ACGT]
-#     # x = [string(i, j) for i in ACGT, j in ACGT]
-#     Dict(x .=> 0)
-# end
-# const DINUCLEOTIDES = vec([LongSequence{DNAAlphabet{2}}([i, j]) for i in ACGT, j in ACGT])
-# const DINUCLEOTIDES_DICT = Dict(BioMarkovChains.DINUCLEOTIDES .=> 0)
-
-#const EXTENDED_DINUCLEOTIDES = vec([LongSequence{DNAAlphabet{4}}([i, j]) for i in alphabet(DNA), j in alphabet(DNA)])
-#const EXTENDED_DINUCLEOTIDES_DICT = Dict(BioMarkovChains.EXTENDED_DINUCLEOTIDES .=> 0)
-
-# const DINUCLEOTIDES = Dict((i, j) => 0 for (i, j) in Iterators.product(ACGT, ACGT))
-# const EXTENDED_DINUCLEOTIDES = Dict((i, j) => 0 for (i, j) in Iterators.product(alphabet(DNA), alphabet(DNA)))
-
-"""
-TransitionCountMatrix(alphabet::Vector{DNA})
-
-A data structure for storing a DNA Transition Count Matrix (TCM). The TCM is a square matrix where each row and column corresponds to a nucleotide in the given `alphabet`. The value at position (i, j) in the matrix represents the number of times that nucleotide i is immediately followed by nucleotide j in a DNA sequence. 
-
-Fields:
-- `order::Dict{DNA, Int64}`: A dictionary that maps each nucleotide in the `alphabet` to its corresponding index in the matrix.
-- `counts::Matrix{Int64}`: The actual matrix of counts.
-
-Internal function:
-- `TransitionCountMatrix(alphabet::Vector{DNA})`: Constructs a new `TCM` object with the given `alphabet`. This function initializes the `order` field by creating a dictionary that maps each nucleotide in the `alphabet` to its corresponding index in the matrix. It also initializes the `counts` field to a matrix of zeros with dimensions `len x len`, where `len` is the length of the `alphabet`.
-
-Example usage:
-```julia
-alphabet = [DNA_A, DNA_C, DNA_G, DNA_T]
-dtcm = TCM(alphabet)
-```
-"""
-struct TransitionCountMatrix
-    order::Dict{DNA,Int64}
-    counts::Matrix{Int64}
-
-    function TransitionCountMatrix(alphabet::Vector{DNA})
-
-        len = length(alphabet)
-
-        order = Dict{DNA,Int}()
-        for (i, nucleotide) in enumerate(sort(alphabet))
-            order[nucleotide] = i
-        end
-        counts = zeros(Int64, len, len)
-        new(order, counts)
-    end
-end
-
-
-"""
-    TransitionProbabilityMatrix(alphabet::Vector{DNA})
-
-A data structure for storing a DNA Transition Probability Matrix (TransitionProbabilityMatrix). The TransitionProbabilityMatrix is a square matrix where each row and column corresponds to a nucleotide in the given `alphabet`. The value at position (i, j) in the matrix represents the probability of transitioning from nucleotide i to nucleotide j in a DNA sequence. 
-
-Fields:
-- `order::Dict{DNA, Int64}`: A dictionary that maps each nucleotide in the `alphabet` to its corresponding index in the matrix.
-- `probabilities::Matrix{Float64}`: The actual matrix of probabilities.
-
-Example usage:
-```julia
-alphabet = [DNA_A, DNA_C, DNA_G, DNA_T]
-dTransitionProbabilityMatrix = TransitionProbabilityMatrix(alphabet)
-```
-"""
-struct TransitionProbabilityMatrix
-    order::Dict{DNA,Int64}
-    probabilities::Matrix{Float64}
-end
+const AA20 = (AA_A, AA_R, AA_N, AA_D, AA_C, AA_Q, AA_E, AA_G, AA_H, AA_I, AA_L, AA_K, AA_M, AA_F, AA_P, AA_S, AA_T, AA_W, AA_Y, AA_V)
 
 """
     struct TransitionModel
@@ -109,12 +38,10 @@ The `TransitionModel` struct represents a transition model used in a sequence an
 
 # Constructors
 
-- `TransitionModel(TransitionProbabilityMatrix::Matrix{Float64}, initials::Matrix{Float64})`: Constructs a `TransitionModel` object with the provided transition probability matrix `TransitionProbabilityMatrix` and initial distribution probabilities `initials`.
-- `TransitionModel(sequence::LongSequence{DNAAlphabet{4}})`: Constructs a `TransitionModel` object based on a given DNA sequence. The transition probability matrix is calculated using `transition_probability_matrix(sequence).probabilities`, and the initial distribution probabilities are calculated using `initial_distribution(sequence)`.
-
+- `TransitionModel(tpm::Matrix{Float64}, initials::Matrix{Float64}; n::Int64=1)`: Constructs a `TransitionModel` object with the provided transition probability matrix and initial distribution probabilities.
 """
 struct TransitionModel <: BioMarkovChain
     tpm::Matrix{Float64} # The probabilities of the TransitionProbabilityMatrix struct
-    initials::Vector{Float64}
+    initials::Vector{Float64} # the initials distribution of probabilities
     n::Int64 # The order of the Markov chain
 end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -1,7 +1,7 @@
 """
-    dinucleotides(sequence::LongNucOrView{4})
+    transitions(sequence::LongSequence)
 
-Compute the transition counts of each dinucleotide in a given DNA sequence.
+Compute the transition counts of each pair in a given biological sequence sequence.
 
 # Arguments
 - `sequence::LongSequence{DNAAlphabet{4}}`: a `LongSequence{DNAAlphabet{4}}` object representing the DNA sequence.
@@ -23,9 +23,9 @@ Dict{Tuple{DNA, DNA}, Int64} with 4 entries:
   (DNA_A, DNA_G) => 3
 ```
 """
-function dinucleotides(sequence::LongNucOrView{4})
+function transitions(sequence::LongSequence)
     b = @view sequence[begin+1:end]
-    dinucleotides = countmap(zip(sequence, b))
+    return countmap(zip(sequence, b))
 end
 
 """


### PR DESCRIPTION
- prepeare transitions method
- reduce types focusing on `transition_model`
- improve methods to handle more alphabets
- update models
- export more BioSequences functions and types
- update `perronfrobenius`
- reduce show methods
- update CHLOG and bump minor release
