### PR TITLE
Update tcm methods to new VK version

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -21,12 +21,12 @@ BioSequences = "3"
 DiscreteMarkovChains = "0.2"
 MarkovChainHammer = "0"
 PrecompileTools = "1"
-VectorizedKmers = "0.8"
+VectorizedKmers = "0.9"
 julia = "1"
 
 [extras]
-Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
 test = ["Test", "Aqua"]

--- a/src/extended.jl
+++ b/src/extended.jl
@@ -13,7 +13,7 @@ function Base.show(
     alphabet_type = eltype(model)
 
     # Print the type name with inferred alphabet type
-    println(io, "BioMarkovChain of $alphabet_type:")
+    println(io, "BioMarkovChain of $alphabet_type and order $(model.n):")
 
     # Print the transition probability matrix
     println(io, "  - Transition Probability Matrix -> Matrix{Float64}($(size(model.tpm, 1)) × $(size(model.tpm, 2))):")
@@ -43,24 +43,11 @@ function Base.show(
         println(io, "   ", round(model.inits[row], digits=4))
     end
 
-    # Print the value of 'n'
-    println(io, "  - Markov Chain Order -> Int64:")
-    println(io, "   ", "$(model.n)")
+    # # Print the value of 'n'
+    # println(io, "  - Markov Chain Order -> Int64:")
+    # println(io, "   ", "$(model.n)")
 end
 
 @inline Base.length(bmc::BioMarkovChain) = length(bmc.inits)
 @inline Base.size(bmc::BioMarkovChain) = size(bmc.tpm)
 @inline Base.eltype(bmc::BioMarkovChain) = bmc.alphabet
-
-"""
-    fit!(bmc::BMC, inits:Vector{Float64}, tpm::Matrix{Float64})
-
-Update `bmc` in-place based on information generated from a state sequence.
-"""
-# function StatsAPI.fit!(bmc::BMC, inits::Vector{Float64}, tpm::Matrix{Float64})
-#     bmc.inits .= inits
-#     sum_to_one!(bmc.inits)
-#     bmc.tpm .= tpm
-#     foreach(sum_to_one!, eachrow(bmc.tpm))
-#     return nothing
-# end

--- a/src/extended.jl
+++ b/src/extended.jl
@@ -42,10 +42,6 @@ function Base.show(
     for row in 1:size(model.inits, 1)
         println(io, "   ", round(model.inits[row], digits=4))
     end
-
-    # # Print the value of 'n'
-    # println(io, "  - Markov Chain Order -> Int64:")
-    # println(io, "   ", "$(model.n)")
 end
 
 @inline Base.length(bmc::BioMarkovChain) = length(bmc.inits)

--- a/src/transitions.jl
+++ b/src/transitions.jl
@@ -23,11 +23,13 @@ tcm = transition_count_matrix(seq)
 ```
 """
 function transition_count_matrix(sequence::NucleicSeqOrView{A}) where {A}
-    return copy(count_kmers(sequence, 2).values')
+    counts = count_kmers(sequence, 2).values'
+    return copy(counts)
 end
 
 function transition_count_matrix(sequence::SeqOrView{<:AminoAcidAlphabet})
-    copy(count_kmers(sequence, 2).values')
+    counts = count_kmers(sequence, 2).values'
+    return copy(counts)
 end
 
 @doc raw"""

--- a/src/transitions.jl
+++ b/src/transitions.jl
@@ -22,14 +22,12 @@ tcm = transition_count_matrix(seq)
  2  0  0  0
 ```
 """
-function transition_count_matrix(sequence::NucleicSeqOrView{A}) where A
-    counts = reshape(count_kmers(sequence, 2), (4,4))'
-    return copy(counts)
+function transition_count_matrix(sequence::NucleicSeqOrView{A}) where {A}
+    return copy(count_kmers(sequence, 2).values')
 end
 
 function transition_count_matrix(sequence::SeqOrView{<:AminoAcidAlphabet})
-    counts = reshape(count_kmers(sequence, 2), (20,20))'
-    return copy(counts)
+    copy(count_kmers(sequence, 2).values')
 end
 
 @doc raw"""


### PR DESCRIPTION
This PR updates the `transition_count_matrix` to be compatible with new version of `VectorizedKmers.jl` (v0.9).